### PR TITLE
Disable fork option

### DIFF
--- a/.github/workflows/bump-kde-connect-nightly.yml
+++ b/.github/workflows/bump-kde-connect-nightly.yml
@@ -31,8 +31,9 @@ jobs:
       - name: Bump Formula
         uses: Homebrew/actions/bump-packages@master
         with:
-          token: ${{ secrets.PAT_GITHUB }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           casks: 'kdeconnect@nightly'
+          fork: false
       - name: Find PR number
         id: find-pr
         run: |

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Bump Formula
         uses: Homebrew/actions/bump-packages@master
         with:
-          token: ${{ secrets.PAT_GITHUB }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           formulae: ${{ github.event.inputs.formulae || env.FORMULAE }}
           casks: ${{ github.event.inputs.casks || env.CASKS }}
+          fork: false


### PR DESCRIPTION
Hopefully this allows us to use the builtin github token. I want this so I can avoid provisioning a separate github PAT for the bump workflows in this repository