### PR TITLE
Revert "Disable fork option"

### DIFF
--- a/.github/workflows/bump-kde-connect-nightly.yml
+++ b/.github/workflows/bump-kde-connect-nightly.yml
@@ -31,9 +31,8 @@ jobs:
       - name: Bump Formula
         uses: Homebrew/actions/bump-packages@master
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_GITHUB }}
           casks: 'kdeconnect@nightly'
-          fork: false
       - name: Find PR number
         id: find-pr
         run: |

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Bump Formula
         uses: Homebrew/actions/bump-packages@master
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_GITHUB }}
           formulae: ${{ github.event.inputs.formulae || env.FORMULAE }}
           casks: ${{ github.event.inputs.casks || env.CASKS }}
-          fork: false


### PR DESCRIPTION
Reverts hybras/homebrew-tap#301

Using the github token means dependent workflows are not triggered. We need CI to run for auto-merge and the 'pr-pull` label to work.