### PR TITLE
Deprecate homebrew-createzap formula

### DIFF
--- a/Formula/homebrew-createzap.rb
+++ b/Formula/homebrew-createzap.rb
@@ -6,6 +6,8 @@ class HomebrewCreatezap < Formula
   sha256 "ea7c8dd6a212ee7c1f074c689df29890399c388c22ea0c622857477200130ed1"
   license "MIT"
 
+  deprecate! date: "2026-06-03", because: "homebrew now provides equivalent functionality via generate-zap"
+
   depends_on "fd"
 
   def install

--- a/Formula/homebrew-createzap.rb
+++ b/Formula/homebrew-createzap.rb
@@ -6,7 +6,7 @@ class HomebrewCreatezap < Formula
   sha256 "ea7c8dd6a212ee7c1f074c689df29890399c388c22ea0c622857477200130ed1"
   license "MIT"
 
-  deprecate! date: "2026-06-03", because: "homebrew now provides equivalent functionality via generate-zap"
+  deprecate! date: "2026-06-03", because: :deprecated_upstream
 
   depends_on "fd"
 


### PR DESCRIPTION
## Summary

Mark the `homebrew-createzap` formula as deprecated since Homebrew now provides equivalent functionality via the built-in `generate-zap` command.

- Formula remains functional but displays a deprecation warning on install/upgrade
- Users will be notified that the feature is superseded by Homebrew's native implementation
- Relates to upstream deprecation: https://github.com/hybras/homebrew-createzap/pull/1

## Changes

- Added `deprecate!` stanza to the formula with effective date 2026-06-03
- Users installing or upgrading will see a deprecation notice pointing to the native alternative